### PR TITLE
Remove webextension-polyfill as it's not needed in manifest v3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "[typescript][typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
-  }
+  },
+  "github.copilot.chat.localeOverride": "en"
 }

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,8 @@
     },
     "parser": {
       "unsafeParameterDecoratorsEnabled": true
-    }
+    },
+    "globals": ["browser", "chrome"]
   },
   "json": {
     "parser": {

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -1,12 +1,15 @@
-import { defineManifest } from '@crxjs/vite-plugin';
+import type { ManifestV3Export } from '@crxjs/vite-plugin';
 
 import pkg from './package.json';
 
-export default defineManifest({
+// `ManifestV3Export` doesn't support `browser_specific_settings` for now.
+// So the manifest is validated with `browser._manifest.WebExtensionManifest` instead.
+const manifest: browser._manifest.WebExtensionManifest = {
   manifest_version: 3,
   name: pkg.displayName,
   version: pkg.version,
   description: pkg.description,
+  homepage_url: pkg.homepage,
   action: {
     default_popup: 'index.html',
   },
@@ -17,5 +20,13 @@ export default defineManifest({
   permissions: ['webRequest', 'webNavigation', 'storage'],
   host_permissions: ['https://*/*'],
   minimum_chrome_version:
-    process.env.BROWSER_ENV !== 'firefox' ? '102' : undefined,
-});
+    process.env.BROWSER_ENV !== 'firefox'
+      ? '110' // for `action.setBadgeTextColor`
+      : undefined,
+  browser_specific_settings:
+    process.env.BROWSER_ENV === 'firefox'
+      ? { gecko: { strict_min_version: '115' } } // for `storage.session`
+      : undefined,
+};
+
+export default manifest as ManifestV3Export;

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -2,7 +2,7 @@ import type { ManifestV3Export } from '@crxjs/vite-plugin';
 
 import pkg from './package.json';
 
-// `ManifestV3Export` doesn't support `browser_specific_settings` for now.
+// `ManifestV3Export` doesn't support `browser_specific_settings` for now (v2.0.0-beta.23).
 // So the manifest is validated with `browser._manifest.WebExtensionManifest` instead.
 const manifest: browser._manifest.WebExtensionManifest = {
   manifest_version: 3,

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "fetch:preload": "./scripts/fetch-preload.sh"
   },
   "dependencies": {
-    "solid-js": "^1.8.11",
-    "webextension-polyfill": "^0.10.0"
+    "solid-js": "^1.8.11"
   },
   "devDependencies": {
     "@biomejs/biome": "1.5.2",
     "@crxjs/vite-plugin": "2.0.0-beta.23",
+    "@types/chrome": "^0.0.260",
+    "@types/firefox-webext-browser": "^120.0.0",
     "@types/node": "^20.11.10",
-    "@types/webextension-polyfill": "^0.10.7",
     "solid-devtools": "^0.29.3",
     "stylelint": "^16.2.0",
     "stylelint-config-recess-order": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "A browser extension to check HSTS status of a website",
   "author": "conjLob",
+  "homepage": "https://github.com/conjLob/hsts-checker",
   "license": "GPL-3.0-only",
   "private": true,
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   solid-js:
     specifier: ^1.8.11
     version: 1.8.11
-  webextension-polyfill:
-    specifier: ^0.10.0
-    version: 0.10.0
 
 devDependencies:
   '@biomejs/biome':
@@ -19,12 +16,15 @@ devDependencies:
   '@crxjs/vite-plugin':
     specifier: 2.0.0-beta.23
     version: 2.0.0-beta.23
+  '@types/chrome':
+    specifier: ^0.0.260
+    version: 0.0.260
+  '@types/firefox-webext-browser':
+    specifier: ^120.0.0
+    version: 120.0.0
   '@types/node':
     specifier: ^20.11.10
     version: 20.11.10
-  '@types/webextension-polyfill':
-    specifier: ^0.10.7
-    version: 0.10.7
   solid-devtools:
     specifier: ^0.29.3
     version: 0.29.3(solid-js@1.8.11)(vite@5.0.12)
@@ -1169,18 +1169,39 @@ packages:
       '@babel/types': 7.22.5
     dev: true
 
+  /@types/chrome@0.0.260:
+    resolution: {integrity: sha512-lX6QpgfsZRTDpNcCJ+3vzfFnFXq9bScFRTlfhbK5oecSAjamsno+ejFTCbNtc5O/TPnVK9Tja/PyecvWQe0F2w==}
+    dependencies:
+      '@types/filesystem': 0.0.35
+      '@types/har-format': 1.2.15
+    dev: true
+
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
+
+  /@types/filesystem@0.0.35:
+    resolution: {integrity: sha512-1eKvCaIBdrD2mmMgy5dwh564rVvfEhZTWVQQGRNn0Nt4ZEnJ0C8oSUCzvMKRA4lGde5oEVo+q2MrTTbV/GHDCQ==}
+    dependencies:
+      '@types/filewriter': 0.0.33
+    dev: true
+
+  /@types/filewriter@0.0.33:
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+    dev: true
+
+  /@types/firefox-webext-browser@120.0.0:
+    resolution: {integrity: sha512-L+tDlwNeq0kQGfAYc2sNfKhRWJz9CNRvlbq9HnLibKUiJ3VTThG8sj7xrJF4CtKpEA9eBAr91Z2nnKIAy+xUJg==}
+    dev: true
+
+  /@types/har-format@1.2.15:
+    resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
     dev: true
 
   /@types/node@20.11.10:
     resolution: {integrity: sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
-
-  /@types/webextension-polyfill@0.10.7:
-    resolution: {integrity: sha512-10ql7A0qzBmFB+F+qAke/nP1PIonS0TXZAOMVOxEUsm+lGSW6uwVcISFNa0I4Oyj0884TZVWGGMIWeXOVSNFHw==}
     dev: true
 
   /@webcomponents/custom-elements@1.6.0:
@@ -2577,10 +2598,6 @@ packages:
     dependencies:
       vite: 5.0.12(@types/node@20.11.10)
     dev: true
-
-  /webextension-polyfill@0.10.0:
-    resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
-    dev: false
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}

--- a/src/background.ts
+++ b/src/background.ts
@@ -129,9 +129,12 @@ const setBadge = async (tabId: number, secHeaders: SecurityHeaders) => {
     text: secure ? '✓' : '✕',
     tabId,
   });
-  browser.action.setBadgeTextColor({
+  await browser.action.setBadgeTextColor({
     color: secure ? '#34d058' : '#ea4a5a',
     tabId,
+  });
+  await browser.action.setBadgeBackgroundColor({
+    color: '#282828',
   });
 };
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,4 @@
-import browser from 'webextension-polyfill';
+import browser from './browser.ts';
 
 import preloadList from './preload.json';
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -113,8 +113,9 @@ const setCache = async <T extends SecurityHeadersOrFetching>(
     // https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse
     const size = await browser.storage.session.getBytesInUse?.();
     const limit =
-      (browser.storage.session as chrome.storage.SessionStorageArea)
-        .QUOTA_BYTES ?? 1_000_000; // 1MB
+      'QUOTA_BYTES' in browser.storage.session
+        ? browser.storage.session.QUOTA_BYTES
+        : 1_000_000; // 1MB
 
     if (
       (e instanceof Error && e.name === 'QuotaExceededError') || // This error is out of W3C WebExtensions spec.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,3 @@
+export default (self.browser ?? self.chrome) as
+  | typeof self.browser
+  | typeof self.chrome;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,3 +1,5 @@
-export default (self.browser ?? self.chrome) as
-  | typeof self.browser
-  | typeof self.chrome;
+type Browser = typeof self.browser | typeof self.chrome;
+
+const browser: Browser = self.browser ?? self.chrome;
+
+export default browser;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
-    "types": ["vite/client"],
     "baseUrl": "src",
 
     "moduleResolution": "bundler",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the app to use the latest manifest configuration for improved browser support.
	- Enhanced handling of storage limits and introduced badge color customization for better user feedback.
	- Added compatibility support for different browser APIs to ensure a seamless experience across platforms.
- **Refactor**
	- Improved TypeScript support for Vite projects, enhancing developer experience and code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->